### PR TITLE
Re-enqueing methods on AccessGuard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "access-queue"
 description = "limit the number of simultaneous accesses to a value"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Without Boats <woboats@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This allows an access to re-enqueue itself, putting itself at the back
of the queue. A version which releases and a verison which does not are
both supported.